### PR TITLE
adding resources request and limit in podSpec

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,11 @@ to inject your pods with a cloud-sql-proxy sidecar.
 | Name | Description | Required |
 | ---- | ----------- | -------- |
 | sqlbee.connctd.io.inject | Wether to inject with a cloud-sql-proxy | no |
-| sqlbee.connctd.io.image | Image to be used | no |
+| sqlbee.connctd.io.image | Image to be used, default gcr.io/cloudsql-docker/gce-proxy:1.13 | no |
 | sqlbee.connctd.io.instance | cloud-sql instance to connect to, required if no default is set | maybe |
 | sqlbee.connctd.io.secret | Secret containing credentials | no |
 | sqlbee.connctd.io.caMap | Config map containing root certificates | no | 
+| sqlbee.connctd.io.cpuRequest | value of the sidecar cpu request, defaults to "30m" | no | 
+| sqlbee.connctd.io.memRequest | value of the sidecar memory request, defaults to "50Mi" | no |
+
+

--- a/cmd/sqlbee/main.go
+++ b/cmd/sqlbee/main.go
@@ -16,8 +16,6 @@ var (
 	caConfigMapName   = flag.String("ca-map", "", "Optional name of a config map containing root certs")
 	requireAnnotation = flag.Bool("annotationRequired", false, "If set, the inject annotation is required to inject the object")
 	logLevel          = flag.String("loglevel", "info", "LogLevel")
-	cpuRequest        = flag.String("cpu", "30m", "The amount of CPU to be requested")
-	memoryRequest     = flag.String("mem", "100Mi", "The amount of memory to be requested")
 )
 
 func main() {
@@ -48,8 +46,6 @@ func main() {
 	mutateOpts.DefaultCertVolume = *caConfigMapName
 	mutateOpts.DefaultSecretName = *secretName
 	mutateOpts.RequireAnnotation = *requireAnnotation
-	mutateOpts.CpuRequest = *cpuRequest
-	mutateOpts.MemRequest = *memoryRequest
 
 	opts.Mutate = Mutate(mutateOpts)
 	opts.CertFile = *certPath

--- a/cmd/sqlbee/main.go
+++ b/cmd/sqlbee/main.go
@@ -16,6 +16,8 @@ var (
 	caConfigMapName   = flag.String("ca-map", "", "Optional name of a config map containing root certs")
 	requireAnnotation = flag.Bool("annotationRequired", false, "If set, the inject annotation is required to inject the object")
 	logLevel          = flag.String("loglevel", "info", "LogLevel")
+	cpuRequest        = flag.String("cpu", "30m", "The amount of CPU to be requested")
+	memoryRequest     = flag.String("mem", "100Mi", "The amount of memory to be requested")
 )
 
 func main() {
@@ -46,6 +48,8 @@ func main() {
 	mutateOpts.DefaultCertVolume = *caConfigMapName
 	mutateOpts.DefaultSecretName = *secretName
 	mutateOpts.RequireAnnotation = *requireAnnotation
+	mutateOpts.CpuRequest = *cpuRequest
+	mutateOpts.MemRequest = *memoryRequest
 
 	opts.Mutate = Mutate(mutateOpts)
 	opts.CertFile = *certPath

--- a/cmd/sqlbee/mutate.go
+++ b/cmd/sqlbee/mutate.go
@@ -124,13 +124,9 @@ func mutatePodSpec(volumes []corev1.Volume, proxyContainer *corev1.Container, po
 			podSpec.Containers = append(podSpec.Containers[:i], podSpec.Containers[i+1:]...)
 			break
 		}
-		container.Resources.Limits = corev1.ResourceList{
+		container.Resources.Requests = corev1.ResourceList{
 			corev1.ResourceMemory: resource.MustParse("100Mi"),
 			corev1.ResourceCPU:    resource.MustParse("30m"),
-		}
-		container.Resources.Requests = corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("500Mi"),
-			corev1.ResourceCPU:    resource.MustParse("200m"),
 		}
 	}
 	podSpec.Containers = append(podSpec.Containers, *proxyContainer)

--- a/cmd/sqlbee/mutate.go
+++ b/cmd/sqlbee/mutate.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"k8s.io/api/admission/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -122,6 +123,14 @@ func mutatePodSpec(volumes []corev1.Volume, proxyContainer *corev1.Container, po
 			// If a cloud sql proxy already exists, remove it
 			podSpec.Containers = append(podSpec.Containers[:i], podSpec.Containers[i+1:]...)
 			break
+		}
+		container.Resources.Limits = corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("100Mi"),
+			corev1.ResourceCPU:    resource.MustParse("30m"),
+		}
+		container.Resources.Requests = corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("500Mi"),
+			corev1.ResourceCPU:    resource.MustParse("200m"),
 		}
 	}
 	podSpec.Containers = append(podSpec.Containers, *proxyContainer)

--- a/pkg/sting/sting.go
+++ b/pkg/sting/sting.go
@@ -115,6 +115,11 @@ type Options struct {
 	KeyFile string
 	// Unused so far. Will be required for support of TLS authenticated clients
 	CaFile string
+
+	// The amount of CPU to be requested
+	cpuRequest string
+	// The amount of memory to be requested
+	memRequest string
 }
 
 // Main is a simple helper method which takes an io.Closer and blocks until either


### PR DESCRIPTION
We noticed that injected cloud sql container is requesting the default resources depending namespace where it gets deployed. 
In some cases that can be high or low and we don't want the sqlbee sidecar to depend on that. 
